### PR TITLE
Allow empty host in url for unix socket connection

### DIFF
--- a/src/DbPdoDriver.php
+++ b/src/DbPdoDriver.php
@@ -101,22 +101,20 @@ abstract class DbPdoDriver implements DbDriverInterface
             $this->instance->setAttribute($key, $value);
         }
     }
-    
+
     protected function createPboConnStr(Uri $connUri)
     {
         $host = $connUri->getHost();
-        if (empty($host)) {
-            return $connUri->getScheme() . ":" . $connUri->getPath();
+
+        $strcnn = $connUri->getScheme() . ":";
+        if (!empty($host)) {
+            $strcnn .= "host=" . $connUri->getHost();
         }
 
         $database = preg_replace('~^/~', '', $connUri->getPath());
         if (!empty($database)) {
-            $database = ";dbname=$database";
+            $strcnn .= ";dbname=$database";
         }
-
-        $strcnn = $connUri->getScheme() . ":"
-            . "host=" . $connUri->getHost()
-            . $database;
 
         if ($connUri->getPort() != "") {
             $strcnn .= ";port=" . $connUri->getPort();


### PR DESCRIPTION
I'm using migration and migration-cli, and would like to apply migrations in an initialization script in the official postgresql docker image.
While running the initialization scripts, the image is configured so that postgres only listens to local unix socket connections.
Pdo supports passing an empty host string to connect to the default unix socket path (at least for postgres), so I think it makes sense to support it here also.

I've tested this successfully with e.g.
`migrate install -p ./migrations pgsql://${POSTGRES_USER}@/my_database`

