### PR TITLE
Change Pre-Fetch Behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $conn = \ByJG\AnyDataset\Db\Factory::getDbInstance("mysql://root:password@10.0.1
 - [Passing Parameters to PDODriver](docs/parameters.md)
 - [Generic PDO Driver](docs/generic-pdo-driver.md)
 - [Running Tests](docs/tests.md)
+- [Pre Fetch records](docs/prefetch.md)
 
 ## Database Specifics
 

--- a/README.md
+++ b/README.md
@@ -43,16 +43,19 @@ $conn = \ByJG\AnyDataset\Db\Factory::getDbInstance("mysql://root:password@10.0.1
 
 - [Getting Started](docs/getting-started.md)
 - [Basic Query and Update](docs/basic-query.md)
+- [Sql Statement Object](docs/sqlstatement.md)
 - [Cache results](docs/cache.md)
 - [Database Transaction](docs/transaction.md)
 - [Load Balance and Connection Pooling](docs/load-balance.md)
 - [Database Helper](docs/helper.md)
+- [Filtering the Query](docs/iteratorfilter.md)
 
 ## Advanced Topics
 
 - [Passing Parameters to PDODriver](docs/parameters.md)
 - [Generic PDO Driver](docs/generic-pdo-driver.md)
 - [Running Tests](docs/tests.md)
+- [Getting an Iterator from an existing PDO Statament](docs/pdostatement.md)
 - [Pre Fetch records](docs/prefetch.md)
 
 ## Database Specifics
@@ -60,6 +63,7 @@ $conn = \ByJG\AnyDataset\Db\Factory::getDbInstance("mysql://root:password@10.0.1
 - [MySQL](docs/mysql.md)
 - [Oracle](docs/oracle.md)
 - [SQLServer](docs/sqlserver.md)
+- [Literal PDO Connection String](docs/literal-pdo-driver.md)
 
 
 ## Install

--- a/docs/basic-query.md
+++ b/docs/basic-query.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Basics
 
 ## Basic Query

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Cache results
 
 You can easily cache your results to speed up the results of long queries;

--- a/docs/generic-pdo-driver.md
+++ b/docs/generic-pdo-driver.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 10
+---
+
 # Generic PDO configuration
 
 If you want to use a PDO driver that is not mapped into the `anydataset-db` library you can use the generic PDO driver.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Getting Started
 
 ## 1. Install the ByJG AnyDatasetDB library

--- a/docs/helper.md
+++ b/docs/helper.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 7
+---
+
 # Helper - DbFunctions
 
 AnyDataset has a helper `ByJG\AnyDataset\Db\DbFunctionsInterface` that can be return some specific data based on the database connection. 

--- a/docs/iteratorfilter.md
+++ b/docs/iteratorfilter.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 8
+---
+
 # Using IteratorFilter
 
 `IteratorFilter` is a class that helps you to create a filter to be used in the Iterator. 

--- a/docs/literal-pdo-driver.md
+++ b/docs/literal-pdo-driver.md
@@ -1,7 +1,14 @@
+---
+sidebar_position: 16
+---
+
 # Literal PDO configuration
 
-If you want to use a PDO driver, and it requires special parameters don't fit well using the URI model you can use the literal object.
-It will allow you to pass the PDO connection string directly.
+If you want to use a PDO driver and this driver is not available in the AnyDatasetDB or and it requires special
+parameters don't fit well
+using the URI model you can use the literal object.
+
+The `PdoLiteral` object uses the PDO connection string instead of the URI model.
 
 Example:
 
@@ -11,6 +18,10 @@ Example:
 $literal = new \ByJG\AnyDataset\Db\PdoLiteral("sqlite::memory:");
 ```
 
-The general rule is use the string as you would use in the PDO constructor.
+Drawbacks:
+
+* You can't use the `Factory::getDbInstance` to get the database instance. You need to use the `PdoLiteral` object
+  directly.
+* The DBHelper won't work with the `PdoLiteral` object.
 
 

--- a/docs/literal-pdo-driver.md
+++ b/docs/literal-pdo-driver.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 ---
 
 # Literal PDO configuration

--- a/docs/load-balance.md
+++ b/docs/load-balance.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 6
+---
+
 # Load balancing
 
 The API have support for connection load balancing, connection pooling and persistent connection.

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 13
+---
+
 # Driver: MySQL
 
 The connection string can have special attributes to connect using SSL. 

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 ---
 
 # Driver: MySQL

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 ---
 
 # Driver: Oracle

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 14
+---
+
 # Driver: Oracle
 
 The Oracle Driver don't use the PHP PDO Driver. Instead, uses the OCI library.

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 9
+---
+
 # Passing Parameters to PDODriver
 
 You can pass parameter directly to the PDODriver by adding to the connection string a query parameter with the value.
@@ -17,14 +21,12 @@ AnyDatasetDB has some special parameters:
 
 | Parameter                      | Value     | Description                                                                                                               |
 |--------------------------------|-----------|---------------------------------------------------------------------------------------------------------------------------|
-| DbPdoDriver::STATEMENT_CACHE   | true      | If this parameter is set with "true", anydataset will cache the last prepared queries.                                    |
 | DbPdoDriver::DONT_PARSE_PARAM  | any value | Is this parameter is set with any value, anydataset won't try to parse the SQL to find the values to bind the parameters. |
 | DbPdoDriver::UNIX_SOCKET       | path      | PDO will use "unix_socket=" instead of "host=".                                                                           |
 e.g.
 
 ```php
 $uri = Uri::getInstanceFromString("sqlite://" . $this->host)
-    ->withQueryKeyValue(DbPdoDriver::STATEMENT_CACHE, "true")
     ->withQueryKeyValue(DbPdoDriver::DONT_PARSE_PARAM, "");
 ```
 

--- a/docs/pdostatement.md
+++ b/docs/pdostatement.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 12
+---
+
+# Using a PDO Statement
+
+If you have a PDO Statement created outside the AnyDatasetDB library,
+you can use it to create an iterator.
+
+```php
+<?php
+$pdo = new PDO('sqlite::memory:');
+$stmt = $pdo->prepare('select * from info where id = :id');
+$stmt->execute(['id' => 1]);
+
+$iterator = $this->dbDriver->getIterator($stmt);
+$this->assertEquals(
+    [
+        [ 'id'=> 1, 'iduser' => 1, 'number' => 10.45, 'property' => 'xxx'],
+    ],
+    $iterator->toArray()
+);
+```
+
+Note:
+
+* Although you can use a PDO Statement, it is recommended to use the
+  `SqlStatement` or `DbDriverInterface` to get the Query.
+* Use this feature with legacy code or when you have a specific need to use a PDO Statement.
+
+## Benefits
+
+You can integrate the AnyDatasetDB library with your legacy code and get the benefits of the library
+as for example the standard `GenericIterator` 
+
+
+

--- a/docs/prefetch.md
+++ b/docs/prefetch.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 13
+---
+
 # Pre Fetch records
 
 By Default the records are fetched from the database when you iterate over the records using for example `moveNext()`,

--- a/docs/prefetch.md
+++ b/docs/prefetch.md
@@ -1,0 +1,60 @@
+# Pre Fetch records
+
+By Default the records are fetched from the database when you iterate over the records using for example `moveNext()`,
+`toArray()` or `foreach`.
+
+You can pre-fetch a number of records when you get the iterator.
+
+```php
+<?php
+$sql = new SqlStatement("select * from table where field = :param");
+
+// Pre-fetch 100 records
+$iterator = $sql->getIterator($dbDriver, ['param' => 'value'], preFetch: 100);
+```
+
+or
+
+```php
+<?php
+$iterator = $dbDriver->getIterator($dbDriver, ['param' => 'value'], preFetch: 100);
+```
+
+The commands above will fetch 100 records from the database and store in memory.
+When you iterate over the records, it will get the records from memory instead of the database.
+
+## Use cases for pre-fetch:
+
+### Small tables with a few records
+
+If you have a small table with a few records, it is better to fetch all records at once and store in memory
+while you iterate over the records.
+
+### Long processing time
+
+If you have a long processing time between the records, it is better to prefetch the records at once and store in memory
+releasing database resources earlier.
+
+## When not to use pre-fetch
+
+In these cases, it is better to fetch the records from the database without pre-fetching, because you can have memory
+issues:
+
+* if your records are too large (e.g. dozens of columns)
+* If you have a field like a blob or large text
+
+## How it works
+
+When you get the `getIterator` it will fetch the number of records you defined from the database and store in memory.
+When you iterate over the records, it will get the records from memory instead of the database and fetch a new one and
+store in memory.
+
+e.g.:
+
+* You have a table with 60 records and define the preFetch of 50.
+* When you get the iterator, it will fetch 50 records from the database and store in memory.
+* For each record you iterate over, it will get the record from memory and fetch a new one from the database.
+* When you reach the 60th record, the iterator will close the cursor from the database, and allow you fetch the
+  remaining records from memory. 
+
+

--- a/docs/sqlserver.md
+++ b/docs/sqlserver.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 15
+---
+
 # Driver: Microsoft SQL Server
 
 There are two Drivers to connect to Microsoft SQL Server.

--- a/docs/sqlserver.md
+++ b/docs/sqlserver.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 ---
 
 # Driver: Microsoft SQL Server

--- a/docs/sqlstatement.md
+++ b/docs/sqlstatement.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # SQL Statement
 
 The SQL Statement is a class to abstract the SQL query from the database.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 11
+---
+
 # Running Unit tests
 
 ## Unit Tests (no DBConnection)

--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # Database Transaction
 
 ## Basics

--- a/src/DbDriverInterface.php
+++ b/src/DbDriverInterface.php
@@ -23,9 +23,10 @@ interface DbDriverInterface extends DbTransactionInterface
      * @param array|null $params
      * @param CacheInterface|null $cache
      * @param int|DateInterval $ttl
+     * @param int $preFetch
      * @return GenericIterator
      */
-    public function getIterator(mixed $sql, ?array $params = null, ?CacheInterface $cache = null, DateInterval|int $ttl = 60): GenericIterator;
+    public function getIterator(mixed $sql, ?array $params = null, ?CacheInterface $cache = null, DateInterval|int $ttl = 60, int $preFetch = 0): GenericIterator;
 
     public function getScalar(mixed $sql, ?array $array = null): mixed;
 

--- a/src/DbOci8Driver.php
+++ b/src/DbOci8Driver.php
@@ -143,11 +143,10 @@ class DbOci8Driver implements DbDriverInterface
      * @param array|null $params
      * @param CacheInterface|null $cache
      * @param int|DateInterval $ttl
+     * @param int $preFetch
      * @return GenericIterator
-     * @throws DatabaseException
-     * @throws DbDriverNotConnected
      */
-    public function getIterator(mixed $sql, ?array $params = null, ?CacheInterface $cache = null, DateInterval|int $ttl = 60): GenericIterator
+    public function getIterator(mixed $sql, ?array $params = null, ?CacheInterface $cache = null, DateInterval|int $ttl = 60, int $preFetch = 0): GenericIterator
     {
         if (is_resource($sql)) {
             return new Oci8Iterator($sql);
@@ -162,7 +161,7 @@ class DbOci8Driver implements DbDriverInterface
             throw new InvalidArgumentException("The SQL must be a cursor, string or a SqlStatement object");
         }
 
-        return $sql->getIterator($this, $params);
+        return $sql->getIterator($this, $params, $preFetch);
     }
 
     /**

--- a/src/DbOci8Driver.php
+++ b/src/DbOci8Driver.php
@@ -149,7 +149,7 @@ class DbOci8Driver implements DbDriverInterface
     public function getIterator(mixed $sql, ?array $params = null, ?CacheInterface $cache = null, DateInterval|int $ttl = 60, int $preFetch = 0): GenericIterator
     {
         if (is_resource($sql)) {
-            return new Oci8Iterator($sql);
+            return new Oci8Iterator($sql, $preFetch);
         }
 
         if (is_string($sql)) {

--- a/src/DbPdoDriver.php
+++ b/src/DbPdoDriver.php
@@ -129,10 +129,10 @@ abstract class DbPdoDriver implements DbDriverInterface
         $statement->execute();
     }
 
-    public function getIterator(mixed $sql, ?array $params = null, ?CacheInterface $cache = null, DateInterval|int $ttl = 60): GenericIterator
+    public function getIterator(mixed $sql, ?array $params = null, ?CacheInterface $cache = null, DateInterval|int $ttl = 60, int $preFetch = 0): GenericIterator
     {
         if ($sql instanceof PDOStatement) {
-            return new DbIterator($sql);
+            return new DbIterator($sql, $preFetch);
         }
 
         if (is_string($sql)) {
@@ -144,7 +144,7 @@ abstract class DbPdoDriver implements DbDriverInterface
             throw new InvalidArgumentException("The SQL must be a cursor, string or a SqlStatement object");
         }
 
-        return $sql->getIterator($this, $params);
+        return $sql->getIterator($this, $params, $preFetch);
     }
 
     public function getScalar(mixed $sql, ?array $array = null): mixed

--- a/src/Oci8Iterator.php
+++ b/src/Oci8Iterator.php
@@ -3,17 +3,11 @@
 namespace ByJG\AnyDataset\Db;
 
 use ByJG\AnyDataset\Core\GenericIterator;
-use ByJG\AnyDataset\Core\Row;
-use ByJG\Serializer\Exception\InvalidArgumentException;
+use ByJG\AnyDataset\Db\Traits\PreFetchTrait;
 
 class Oci8Iterator extends GenericIterator
 {
-
-    const RECORD_BUFFER = 50;
-
-    private array $rowBuffer;
-    protected int $currentRow = 0;
-    protected int $moveNextRow = 0;
+    use PreFetchTrait;
 
     /**
      * @var resource Cursor
@@ -24,10 +18,10 @@ class Oci8Iterator extends GenericIterator
      *
      * @param resource $cursor
      */
-    public function __construct($cursor)
+    public function __construct($cursor, int $preFetch = 0)
     {
         $this->cursor = $cursor;
-        $this->rowBuffer = array();
+        $this->initPreFetch($preFetch);
     }
 
     /**
@@ -39,67 +33,26 @@ class Oci8Iterator extends GenericIterator
         return -1;
     }
 
-    /**
-     * @access public
-     * @return bool
-     * @throws InvalidArgumentException
-     */
-    public function hasNext(): bool
+    public function fetchRow(): array|bool
     {
-        if (count($this->rowBuffer) >= Oci8Iterator::RECORD_BUFFER) {
-            return true;
-        }
+        return oci_fetch_assoc($this->cursor);
+    }
 
-        if (is_null($this->cursor)) {
-            return (count($this->rowBuffer) > 0);
-        }
+    public function isCursorOpen(): bool
+    {
+        return !is_null($this->cursor);
+    }
 
-        $rowArray = oci_fetch_assoc($this->cursor);
-        if (!empty($rowArray)) {
-            $rowArray = array_change_key_case($rowArray, CASE_LOWER);
-            $singleRow = new Row($rowArray);
-
-            $this->currentRow++;
-
-            // Enfileira o registo
-            $this->rowBuffer[] = $singleRow;
-            // Traz novos até encher o Buffer
-            if (count($this->rowBuffer) < DbIterator::RECORD_BUFFER) {
-                $this->hasNext();
-            }
-            return true;
-        }
-
+    public function releaseCursor(): void
+    {
         oci_free_statement($this->cursor);
         $this->cursor = null;
-        return (count($this->rowBuffer) > 0);
     }
 
     public function __destruct()
     {
         if (!is_null($this->cursor)) {
-            oci_free_statement($this->cursor);
-            $this->cursor = null;
+            $this->releaseCursor();
         }
-    }
-
-    /**
-     * @return Row|null
-     * @throws InvalidArgumentException
-     */
-    public function moveNext(): ?Row
-    {
-        if (!$this->hasNext()) {
-            return null;
-        }
-
-        $row = array_shift($this->rowBuffer);
-        $this->moveNextRow++;
-        return $row;
-    }
-
-    public function key(): int
-    {
-        return $this->moveNextRow;
     }
 }

--- a/src/Route.php
+++ b/src/Route.php
@@ -239,13 +239,14 @@ class Route implements DbDriverInterface
      * @param array|null $params
      * @param CacheInterface|null $cache
      * @param int|DateInterval $ttl
+     * @param int $preFetch
      * @return GenericIterator
      * @throws RouteNotMatchedException
      */
-    public function getIterator(mixed $sql, ?array $params = null, ?CacheInterface $cache = null, DateInterval|int $ttl = 60): GenericIterator
+    public function getIterator(mixed $sql, ?array $params = null, ?CacheInterface $cache = null, DateInterval|int $ttl = 60, int $preFetch = 0): GenericIterator
     {
         $dbDriver = $this->matchRoute($sql);
-        return $dbDriver->getIterator($sql, $params, $cache, $ttl);
+        return $dbDriver->getIterator($sql, $params, $cache, $ttl, $preFetch);
     }
 
     /**

--- a/src/SqlStatement.php
+++ b/src/SqlStatement.php
@@ -64,7 +64,7 @@ class SqlStatement
     }
 
 
-    public function getIterator(DbDriverInterface $dbDriver, ?array $param = [])
+    public function getIterator(DbDriverInterface $dbDriver, ?array $param = [], int $preFetch = 0): GenericIterator
     {
         $cacheKey = "";
         if (!empty($this->cache)) {
@@ -87,7 +87,7 @@ class SqlStatement
                 $statement = $dbDriver->prepareStatement($this->sql, $param, $this->cachedStatement);
 
                 $dbDriver->executeCursor($statement);
-                $iterator = $dbDriver->getIterator($statement);
+                $iterator = $dbDriver->getIterator($statement, preFetch: $preFetch);
 
                 if (!empty($this->cache)) {
                     $cachedItem = $iterator->toArray();

--- a/src/Traits/PreFetchTrait.php
+++ b/src/Traits/PreFetchTrait.php
@@ -38,6 +38,10 @@ trait PreFetchTrait
             return true;
         }
 
+        if (!$this->isCursorOpen()) {
+            return false;
+        }
+
         $rowArray = $this->fetchRow();
         if (!empty($rowArray)) {
             $rowArray = array_change_key_case($rowArray, CASE_LOWER);

--- a/src/Traits/PreFetchTrait.php
+++ b/src/Traits/PreFetchTrait.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace ByJG\AnyDataset\Db\Traits;
+
+use ByJG\AnyDataset\Core\Row;
+
+trait PreFetchTrait
+{
+    protected int $currentRow = -1;
+    protected int $preFetchRows = 0;
+    protected array $rowBuffer = [];
+
+    protected function initPreFetch(int $preFetch = 0)
+    {
+        $this->rowBuffer = [];
+        $this->preFetchRows = $preFetch;
+        if ($preFetch > 0) {
+            $this->preFetch();
+        }
+    }
+
+    public function hasNext(): bool
+    {
+        if (count($this->rowBuffer) > 0) {
+            return true;
+        }
+
+        if ($this->isCursorOpen() && $this->preFetch()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    protected function preFetch(): bool
+    {
+        if ($this->isPreFetchBufferFull()) {
+            return true;
+        }
+
+        $rowArray = $this->fetchRow();
+        if (!empty($rowArray)) {
+            $rowArray = array_change_key_case($rowArray, CASE_LOWER);
+            $singleRow = new Row($rowArray);
+
+            // Enfileira o registo
+            $this->rowBuffer[] = $singleRow;
+            // Traz novos até encher o Buffer
+            return $this->preFetch();
+        }
+
+        if ($rowArray === false) {
+            $this->releaseCursor();
+        }
+
+        return false;
+    }
+
+    protected function isPreFetchBufferFull(): bool
+    {
+        if ($this->getPreFetchRows() === 0) {
+            return count($this->rowBuffer) > 0;
+        }
+
+        return count($this->rowBuffer) >= $this->getPreFetchRows();
+    }
+
+    abstract public function isCursorOpen(): bool;
+
+    abstract protected function fetchRow(): array|bool;
+
+    abstract protected function releaseCursor(): void;
+
+    public function getPreFetchRows(): int
+    {
+        return $this->preFetchRows;
+    }
+
+    public function setPreFetchRows(int $preFetchRows): void
+    {
+        $this->preFetchRows = $preFetchRows;
+    }
+
+    public function getPreFetchBufferSize(): int
+    {
+        return count($this->rowBuffer);
+    }
+
+    /**
+     * @return Row|null
+     */
+    public function moveNext(): ?Row
+    {
+        if (!$this->hasNext()) {
+            return null;
+        }
+
+        $singleRow = array_shift($this->rowBuffer);
+        $this->currentRow++;
+        $this->preFetch();
+        return $singleRow;
+    }
+
+    public function key(): int
+    {
+        return $this->currentRow;
+    }
+}

--- a/tests/PdoSqliteTest.php
+++ b/tests/PdoSqliteTest.php
@@ -2,12 +2,10 @@
 
 namespace Test;
 
-use ByJG\AnyDataset\Core\GenericIterator;
 use ByJG\AnyDataset\Db\DbDriverInterface;
 use ByJG\AnyDataset\Db\Factory;
 use ByJG\AnyDataset\Db\Helpers\DbSqliteFunctions;
 use ByJG\AnyDataset\Db\SqlStatement;
-use ByJG\AnyDataset\Db\Traits\PreFetchTrait;
 use ByJG\Cache\Psr16\ArrayCacheEngine;
 use ByJG\Util\Uri;
 use PDO;
@@ -449,10 +447,10 @@ class PdoSqliteTest extends TestCase
     /**
      * @dataProvider dataProviderPreFetch
      * @return void
+     * @psalm-suppress UndefinedMethod
      */
     public function testPreFetchWhile(int $preFetch, array $rows, array $expected)
     {
-        /** @var GenericIterator|PreFetchTrait $iterator */
         $iterator = $this->dbDriver->getIterator('select * from info', preFetch: $preFetch);
 
         $i = 0;
@@ -467,11 +465,11 @@ class PdoSqliteTest extends TestCase
 
     /**
      * @dataProvider dataProviderPreFetch
+     * @psalm-suppress UndefinedMethod
      * @return void
      */
     public function testPreFetchForEach(int $preFetch, array $rows, array $expected)
     {
-        /** @var GenericIterator|PreFetchTrait $iterator */
         $iterator = $this->dbDriver->getIterator('select * from info', preFetch: $preFetch);
 
         $i = 0;

--- a/tests/PdoSqliteTest.php
+++ b/tests/PdoSqliteTest.php
@@ -443,6 +443,22 @@ class PdoSqliteTest extends TestCase
         );
     }
 
+    public function testPDOStatement()
+    {
+        $pdo = $this->dbDriver->getDbConnection();
+        $stmt = $pdo->prepare('select * from info where id = :id');
+        $stmt->execute(['id' => 1]);
+
+        $iterator = $this->dbDriver->getIterator($stmt);
+        $this->assertEquals(
+            [
+                ['id' => 1, 'iduser' => 1, 'number' => 10.45, 'property' => 'xxx'],
+            ],
+            $iterator->toArray()
+        );
+
+    }
+
 
     /**
      * @dataProvider dataProviderPreFetch

--- a/testsdb/BasePdo.php
+++ b/testsdb/BasePdo.php
@@ -114,6 +114,8 @@ abstract class BasePdo extends TestCase
             $singleRow = $iterator->moveNext();
             $this->assertEquals($array[$i++], $singleRow->toArray());
         }
+
+        $this->assertFalse($iterator->isCursorOpen());
     }
 
     public function testExecuteAndGetId()
@@ -206,6 +208,7 @@ abstract class BasePdo extends TestCase
 
         $iterator = $this->dbDriver->getIterator('select Id, Breed, Name, Age, Weight from Dogs where id = 4');
         $row = $iterator->toArray();
+        $this->assertFalse($iterator->isCursorOpen());
 
         $this->assertEquals(4, $row[0]["id"]);
         $this->assertEquals('Dog', $row[0]["breed"]);
@@ -224,6 +227,7 @@ abstract class BasePdo extends TestCase
 
         $iterator = $this->dbDriver->getIterator('select Id, Breed, Name, Age from Dogs where id = 4');
         $row = $iterator->toArray();
+        $this->assertFalse($iterator->isCursorOpen());
 
         $this->assertEquals(4, $row[0]["id"]);
         $this->assertEquals('Dog', $row[0]["breed"]);
@@ -244,6 +248,7 @@ abstract class BasePdo extends TestCase
 
         $iterator = $this->dbDriver->getIterator('select Id, Breed, Name, Age from Dogs where id = 4');
         $row = $iterator->toArray();
+        $this->assertFalse($iterator->isCursorOpen());
 
         $this->assertEquals(4, $row[0]["id"]);
         $this->assertEquals('Dog', $row[0]["breed"]);
@@ -265,6 +270,7 @@ abstract class BasePdo extends TestCase
 
         $iterator = $this->dbDriver->getIterator('select Id, Breed, Name, Age from Dogs where id = 4');
         $row = $iterator->toArray();
+        $this->assertFalse($iterator->isCursorOpen());
 
         $this->assertEquals(4, $row[0]["id"]);
         $this->assertEquals('Dog', $row[0]["breed"]);
@@ -280,6 +286,7 @@ abstract class BasePdo extends TestCase
 
         $iterator = $this->dbDriver->getIterator('select Id, Breed, Name, Age from Dogs where id = 4');
         $row = $iterator->toArray();
+        $this->assertFalse($iterator->isCursorOpen());
 
         $this->assertEquals(4, $row[0]["id"]);
         $this->assertEquals('Dog', $row[0]["breed"]);
@@ -293,6 +300,7 @@ abstract class BasePdo extends TestCase
         $newConn = Factory::getDbInstance($newUri);
         $it = $newConn->getIterator('select Id, Breed, Name, Age from Dogs where id = :field', ["field" => 1]);
         $this->assertCount(1, $it->toArray());
+        $this->assertFalse($it->isCursorOpen());
     }
 
     public function testDontParseParam_2()


### PR DESCRIPTION
The Default pre-fetch was 50 records and it isn't configurable. 

On queries results with long field content, it can get the memory exhausted when was pre-fetching 50 records.

This change disable the preFetch by default, and allow customize how much will be pre-fetched.