### PR TITLE
Fix double colons (::) usage in Postgres queries

### DIFF
--- a/src/Helpers/SqlBind.php
+++ b/src/Helpers/SqlBind.php
@@ -42,7 +42,7 @@ class SqlBind
 
         $sqlAlter = preg_replace("~'.*?((\\\\'|'').*?)*'~", "", $sql);
         preg_match_all(
-            "/:(?<param>[_\\w\\d]+)\b/",
+            "/(?<!:):(?<param>[_\\w\\d]+)\b/",
             $sqlAlter,
             $matches
         );
@@ -58,7 +58,7 @@ class SqlBind
                 // Remove NON DEFINED parameters
                 $sql = preg_replace(
                     [
-                        "/:$paramName\b/"
+                        "/(?<!:):$paramName\b/"
                     ],
                     [
                         "null"
@@ -74,7 +74,7 @@ class SqlBind
             $count = 0;
             $sql = preg_replace(
                 [
-                    "/:$paramName\b/",
+                    "/(?<!:):$paramName\b/",
                 ],
                 [
                     $dbArg,

--- a/tests/Helpers/SqlBindTest.php
+++ b/tests/Helpers/SqlBindTest.php
@@ -118,4 +118,30 @@ class SqlBindTest extends TestCase
             )
         );
     }
+
+    public function testPostgresTypecast()
+    {
+        $paramIn = [
+            'name' => 'John',
+            'surname' => 'Doe',
+            'age' => 43
+        ];
+
+        // Test with Postgres type casting (::)
+        $uri = new Uri('pgsql://host');
+        $sql = 'SELECT column::text, :name, :surname FROM table WHERE age = :age';
+        $expected = 'SELECT column::text, :name, :surname FROM table WHERE age = :age';
+
+        $this->assertEquals(
+            [
+                $expected,
+                $paramIn
+            ],
+            SqlBind::parseSQL(
+                $uri,
+                $sql,
+                $paramIn
+            )
+        );
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue with double colons (::) in Postgres queries, ensuring proper syntax and compatibility.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Improve the handling of parameter binding in Postgres queries by ensuring that the single colon (:) used for parameters is not confused with double colons (::) used for typecasting, and add tests to verify this behavior.

### Why are these changes being made?

The existing implementation incorrectly interprets Postgres typecasts (::) as if they were binding parameters, which causes issues in parameter substitution within queries. This update uses a negative lookbehind regex pattern to correctly differentiate between single colons for parameters and double colons for casting, ensuring accurate SQL query preparation. The changes also include tests to validate that typecasting in queries works correctly alongside parameter binding.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->